### PR TITLE
Update README.md for raw link to audit.rb

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Installing knife-audit
 
 #### Script install
 
-Copy the knife-audit script from https://github.com/jbz/knife-audit/blob/master/lib/chef/knife/audit.rb to your .chef/plugins/knife directory.   Note that script-installed knife audit will be unable to install the knife_audit helper cookbook for you.
+Copy the knife-audit script from https://raw.githubusercontent.com/jbz/knife-audit/master/lib/chef/knife/audit.rb to your .chef/plugins/knife directory.   Note that script-installed knife audit will be unable to install the knife_audit helper cookbook for you.
 
 #### Gem install
 


### PR DESCRIPTION
The script-install link for audit.rb is the html version of the scriopt; this change switches it to the raw version suitable for wget / curl direct to the destination.
