### PR TITLE
fix: node['knife_audit']['seen_recipes'] shows up as an array, not a has...

### DIFF
--- a/lib/chef/knife/audit.rb
+++ b/lib/chef/knife/audit.rb
@@ -131,7 +131,7 @@ module KnifeAudit
         # If yes use seen_recipes if it's available. If it's not available, fall back
         # to the node.recipes contents.
         if (config[:all_cookbooks] || config[:totals])
-          recipes = (node["knife_audit"] && node["knife_audit"]["seen_recipes"].keys) || node.expand!.recipes.to_a
+          recipes = (node["knife_audit"] && node["knife_audit"]["seen_recipes"]) || node.expand!.recipes.to_a
           if node["knife_audit"] && node["knife_audit"]["seen_recipes"]
             node_seen_recipe_flag = true
           end


### PR DESCRIPTION
I'm not sure if this is a chef version difference or a simple mistake.  I'm running chef 11.8.2 and node['knife_audit']['seen_recipes'] shows up as an array, not a hash, so the 'keys' method produces an error on line 134.
