### PR TITLE
Split by recipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ knife-audit is available on rubygems.org - if you have that source in your gemrc
 Usage
 ---------------
 
-    knife audit [-a|-t] [-s] [-i] <COOKBOOK COOKBOOK ...>
+    knife audit [-a|-t] [-r] [-s] [-E <Environment>] [-i] <COOKBOOK COOKBOOK ...>
 
 If no cookbooks are specified, knife-audit will return a list of *all* cookbooks available on the currently configured Chef server or Opscode Platform organization, along with a count for each of how many nodes in the current Chef server or Opscode Platform organization explicitly reference that cookbook in their expanded runlist. 
 
@@ -38,6 +38,10 @@ The '-a' or '--all-cookbooks' option will cause knife-audit to check on each nod
 The '-t' or '--totals' option will cause knife-audit to present a single output section containing the merged totals of all nodes with and without the helper cookbook.  This is less accurate, but still useful and easier to read.
 
 The '-s' or '--show-nodelist' option will cause knife-audit to include in its output a list of all nodes which reference each cookbook.
+
+The '-E' or '--environment' <ENVIRONMENT> option, like the standard knife option, will cause knife-audit to limit the nodes queried to those in the specified environment.
+
+The '-r' or '--recipe-split' option will cause knife-audit to further split its output by the recipes in each cookbook.
 
 The '-i' or '--install-cookbook' option will cause knife-audit to copy the knife_audit helper cookbook into the currently configured Chef cookbook_path.  If there is already a directory or file there with that name, it will abort.  Note that you will need to 'knife cookbook upload knife_audit' once you have done this in order to push the cookbook to your Chef server; in addition, you will need to add the knife_audit cookbook to your node runlists. See 'Helper Cookbook' below for more information.
 

--- a/lib/chef/knife/audit.rb
+++ b/lib/chef/knife/audit.rb
@@ -225,7 +225,7 @@ module KnifeAudit
       key_length = item.empty? ? 0 : item.keys.map {|name| name.size }.max + 2
       if config[:show_nodelist]
         item.sort.map do |name, cookbook|
-          "#{name.ljust(key_length)} #{cookbook["seen_recipe_count"]} [ #{cookbook["seen_recipe_nodes"].sort.join('  ')} ]"
+          "#{name.ljust(key_length)} #{cookbook["seen_recipe_count"]} [ #{cookbook["seen_recipe_nodes"].sort.join('  ').ljust(key_length)} ]"
         end
       else
         item.sort.map do |name, cookbook|
@@ -241,7 +241,7 @@ module KnifeAudit
         item.sort.map do |name, cookbook|
           cookbook_display = (cookbook["seen_recipe_nodes"] + cookbook["nodes"]).uniq
           cookbook_count = cookbook["seen_recipe_count"] + cookbook["count"]
-          "#{name.ljust(key_length)} #{cookbook_count} [ #{cookbook_display.sort.join('  ')} ]"
+          "#{name.ljust(key_length)} #{cookbook_count} " + wrapi(#{cookbook_display.sort.join('  ')},20,key_length + 5)
         end
       else
         item.sort.map do |name, cookbook|
@@ -252,8 +252,10 @@ module KnifeAudit
 
     end # format_cokbook_seenlist... def end
 
-
-
+    def wrapi(s, width=78, ind=20)
+      sp=" " * ind
+      s.gsub(/(.{1,#{width}})(\s+|\Z)/, sp + "\\1\n")
+    end
   end #class end
 
 end #module end

--- a/lib/chef/knife/audit.rb
+++ b/lib/chef/knife/audit.rb
@@ -240,7 +240,7 @@ module KnifeAudit
       item.sort.map do |name, cookbook|
         cookbook_count = cookbook["nodes"].count
         ui.msg("#{name.ljust(@key_length)} #{cookbook['count']}")
-        ui.msg(wrapi("#{cookbook['nodes'].sort.join(' ')}",125, 4) if config[:show_nodelist]
+        ui.msg(wrapi("#{cookbook['nodes'].sort.join(' ')}",125, 4)) if config[:show_nodelist]
         if config[:rec_split]
           cookbook.map do | recipe, stats|
             unless @skip_these.include?(recipe)

--- a/lib/chef/knife/audit.rb
+++ b/lib/chef/knife/audit.rb
@@ -51,6 +51,21 @@ module KnifeAudit
       :long => "--install-cookbook",
       :description => "Install knife_audit helper cookbook into current chef cookbook directory"
 
+    option :version_split,
+      :short => "-v",
+      :long => "--version-split",
+      :description => "Split output by cookbook versions"
+    
+    option :env_split,
+      :short => "-e",
+      :long => "--env-split",
+      :description => "Split output by Chef Environment"
+    
+    option :env_select,
+      :short => "-E ENVIRONMENT",
+      :long => "--environment ENVIRONMENT",
+      :description => "Select Environment"
+
     def run
 
       if @name_args.empty?
@@ -147,7 +162,7 @@ module KnifeAudit
         #     add the node to its running node array
 
         node_cookbook_list.each do |cookbook|
-	        if cookbook_list.has_key?(cookbook)
+	  if cookbook_list.has_key?(cookbook)
             # Up the appropriate ookbook count and add node to appropriate nodes array
             if node_seen_recipe_flag
               cookbook_list[cookbook]["seen_recipe_count"] += 1

--- a/lib/chef/knife/audit.rb
+++ b/lib/chef/knife/audit.rb
@@ -131,7 +131,7 @@ module KnifeAudit
 
       # 2) Get an array of Chef::Nodes known to the current server/org
 
-      query = "*:*"  # find all nodes
+      query = config[:env_select] ? "chef_environment:#{config[:env_select]}" : "*:*"
 
       Shell::Extensions.extend_context_object(self)
       node_list = nodes.find(query)

--- a/lib/chef/knife/audit.rb
+++ b/lib/chef/knife/audit.rb
@@ -241,7 +241,8 @@ module KnifeAudit
         item.sort.map do |name, cookbook|
           cookbook_display = (cookbook["seen_recipe_nodes"] + cookbook["nodes"]).uniq
           cookbook_count = cookbook["seen_recipe_count"] + cookbook["count"]
-          "#{name.ljust(key_length)} #{cookbook_count} " + wrapi(#{cookbook_display.sort.join('  ')},20,key_length + 5)
+          "#{name.ljust(key_length)} #{cookbook_count}"
+          puts wrapi("#{cookbook_display.sort.join('  ')}",20,key_length + 5)
         end
       else
         item.sort.map do |name, cookbook|

--- a/lib/chef/knife/audit.rb
+++ b/lib/chef/knife/audit.rb
@@ -61,11 +61,6 @@ module KnifeAudit
       :long => "--env-split",
       :description => "Split output by Chef Environment"
     
-    option :env_select,
-      :short => "-E ENVIRONMENT",
-      :long => "--environment ENVIRONMENT",
-      :description => "Select Environment"
-
     def run
 
       if @name_args.empty?
@@ -76,7 +71,8 @@ module KnifeAudit
 
       self.config = Chef::Config.merge!(config)
 
-      # If :install_cookbook flag is set, just install the cookbook and return (exit).
+      # puts config
+      # if :install_cookbook flag is set, just install the cookbook and return (exit).
       if config[:install_cookbook]
 
         unless config[:cookbook_path]
@@ -131,7 +127,7 @@ module KnifeAudit
 
       # 2) Get an array of Chef::Nodes known to the current server/org
 
-      query = config[:env_select] ? "chef_environment:#{config[:env_select]}" : "*:*"
+      query = config[:environment] ? "chef_environment:#{config[:environment]}" : "*:*"
 
       Shell::Extensions.extend_context_object(self)
       node_list = nodes.find(query)


### PR DESCRIPTION
I had intended to split these into two Pull requests, but the first was only a one line change, so it didn't seem worth it.  The fist change was implementing knife's standard '-E' option to limit by environment (change on line 136).

Second - I've found knife-audit very useful (thank you), but found myself repeatedly wanting to know the breakdown by recipe, not just by cookbook.  I had to add to nearly every section, so I also tried to consolidate and streamline a little as I went.  I don't believe I've broken anything, but let me know if I have.  This works well for us, with around 50 cookbooks and 400+ servers (and growing).
